### PR TITLE
Ristet Slamming

### DIFF
--- a/frontend/src/fun/jp-ristet/jp-ristet.mjs
+++ b/frontend/src/fun/jp-ristet/jp-ristet.mjs
@@ -159,6 +159,10 @@ class JPRistetElement extends LitElement {
       background-color: var(--jp-color-bg-4);
     }
 
+    .grid-cell.path {
+      background-color: #999;
+    }
+
     .grid-cell.c1 {
       background-color: darkblue;
     }
@@ -270,13 +274,30 @@ class JPRistetElement extends LitElement {
       }
     }
 
+    /*
+     * Fill in blocks that make up the current piece. Also highlights unoccupied blocks
+     * within the current shape that are under a "ceiling", or an occupied block of the
+     * current piece.
+     */
     if (currentPiece) {
       let { pos, shape } = currentPiece;
-      for (let y = 0; y < shape.length; y++) {
-        for (let x = 0; x < shape[y].length; x++) {
+      for (let x = 0; x < shape[0].length; x++) {
+        let foundCeiling = false;
+        for (let y = 0; y < shape.length; y++) {
           if (shape[y][x]) {
             colorMap[pos.y + y][pos.x + x] = currentPiece.name;
-          }
+            foundCeiling = true;
+          } else if (foundCeiling && colorMap[pos.y + y][pos.x + x] === 'off')
+            colorMap[pos.y + y][pos.x + x] = 'path';
+        }
+      }
+
+      // Highlight unoccupied blocks under the current piece (until an occupied one is hit)
+      for(let col = pos.x; col < pos.x + shape[0].length; col++) {
+        for (let row = pos.y + shape.length; row < ROWS; row++) {
+          if (colorMap[row][col] !== 'off')
+            break;
+          colorMap[row][col] = 'path';
         }
       }
     }
@@ -612,6 +633,9 @@ class JPRistetElement extends LitElement {
           case 'ArrowRight':
             event.preventDefault();
             this.commitData(this.movementSimulate(DIRECTION.RIGHT));
+            break;
+          case 'ArrowUp':
+            event.preventDefault();
             break;
           case '1':
             event.preventDefault();

--- a/frontend/src/fun/jp-ristet/jp-ristet.mjs
+++ b/frontend/src/fun/jp-ristet/jp-ristet.mjs
@@ -160,7 +160,7 @@ class JPRistetElement extends LitElement {
     }
 
     .grid-cell.path {
-      background-color: #999;
+      background-color: #9996;
     }
 
     .grid-cell.c1 {
@@ -636,6 +636,9 @@ class JPRistetElement extends LitElement {
             break;
           case 'ArrowUp':
             event.preventDefault();
+            let result = this.movementSimulate(DIRECTION.DOWN);
+            while(!(result instanceof MovementError)) result = this.movementSimulate(DIRECTION.DOWN);
+            this.commitData(result);
             break;
           case '1':
             event.preventDefault();


### PR DESCRIPTION
Implements two things:
1. "Slamming" i.e. pressing the up arrow key and immediately pushing the current piece down as far as it can go
2. "Path highlighting", or showing the path the current piece will take

Edits welcome, there could def be a cleaner way to do this. Just opening the PR so you can try it out locally and give any suggestions.